### PR TITLE
Start full step anti-clockwise rotation with 4th step

### DIFF
--- a/Kinetics/StepperMotors/28BYJ48/DirectDrive/DirectDrive.ino
+++ b/Kinetics/StepperMotors/28BYJ48/DirectDrive/DirectDrive.ino
@@ -130,6 +130,7 @@ void fullStepDemo() {
   }
   delay(DEMO_DELAY);
 
+  step=3; //counter clockwise rotation should start with the 4th step
   for(int i=0; i < STEPS_PER_REVOLUTION; ++i) {
     clockwise = false;
     fullStep();


### PR DESCRIPTION
Counter-clockwise rotation should start with the 4th step (step=3) for a perfect return to the original position after clockwise rotation. The effect is quite small for a single run of fullStepDemo(). But it may be visible for fullStepDemo() in a loop.